### PR TITLE
feat: add configuration for a private github registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,17 @@ If the configuration does not fit your project, you can exclude certain presets 
   ]
 }
 ````
+
+## Supporting updates from a private registry
+
+If you're relying on SMG packages shipped via private npm registry you can add
+
+````json
+{
+  "extends": [
+    "github>smg-automotive/renovate-config:npmGitHubRegistry"
+  ]
+}
+````
+
+to your configuration to allow renovate checking for dependency updates.

--- a/npmGitHubRegistry.json
+++ b/npmGitHubRegistry.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "hostRules": [
+    {
+      "matchHost": "https://npm.pkg.github.com/",
+      "hostType": "npm",
+      "encrypted": {
+        "token": "wcBMA8xOaBJvzJNbAQf+JkVZJItT35yC//J2ckDZ1zGclRAx3lb1FtNl6shhJKNvtfE04OLTFMhh7LdrrL+naXuCVWgoF7YayaTVVmbKhcr7pIg3KpvyrzMmZscL6WdaZr94LjfTumJFZshZ1DyRFqlraFXD/SuQdoqoSNPZwKqffvhavW3N7BlVZhtHhmkoc/XzDl2hu68V4mgXkDJP+Fs21+8i7RivKF2aqW63czsLu2czt8BGFEd2XXlTEImQGRjFZNSlGksZW9RaMaQQfRgxPHeiMqUkw/1ACnjrWO4rvF8yDwRjFBQIUpUyHethDLYvIGOjNWK23S86sbz3L8QTsZGf5pRRry7IEpN/XtJ4ATxe65/145HdAkicAjuMPj2o5RMCic5DmgqOiDHpSKkxlTeIpsShyfw6KFUZwQ8C/2TUhdgkpcuaalLEL0GZUH+eEu7BTbWkVUbKJW9jf0RgJNDEfiSv/ZbWvaz/MtzJ8QGSeeh8LjW7ZkMWajdMuhpivBQf1sWQ"
+      }
+    }
+  ],
+  "npmrc": "@smg-group:registry=https://npm.pkg.github.com/"
+}


### PR DESCRIPTION
Adds configuration for a private smg-group package registry do that we can check for updates of the appnexus.

[Relevant docs](https://docs.renovatebot.com/getting-started/private-packages/#automatically-authenticate-for-npm-package-stored-in-private-github-npm-repository)